### PR TITLE
perf: no need to check for initialization before setting it

### DIFF
--- a/src/uMSAAdvaced.sol
+++ b/src/uMSAAdvaced.sol
@@ -245,8 +245,7 @@ contract MSAAdvanced is ExecutionHelper, IERC7579Account, ModuleManager, HookMan
      * @inheritdoc IERC7579Account
      */
     function initializeAccount(bytes calldata data) public payable virtual override {
-        // only allow initialization once
-        if (isAlreadyInitialized()) revert();
+        // checks if already initialized and reverts before setting the state to initialized
         _initModuleManager();
 
         // this is just implemented for demonstration purposes. You can use any other initialization

--- a/src/uMSABasic.sol
+++ b/src/uMSABasic.sol
@@ -152,8 +152,7 @@ contract MSABase is ExecutionHelper, IERC7579Account, ModuleManager {
      * @inheritdoc IERC7579Account
      */
     function initializeAccount(bytes calldata data) public payable virtual override {
-        // only allow initialization once
-        if (isAlreadyInitialized()) revert AccountInitializationFailed();
+        // checks if already initialized and reverts before setting the state to initialized
         _initModuleManager();
 
         // this is just implemented for demonstration purposes. You can use any other initialization


### PR DESCRIPTION
There is no need to check if the module was initialized because `ModuleManager` uses the `SentinelList` library, which checks before setting the initialized state.

`ModuleManager`

https://github.com/erc7579/uMSA/blob/4820e68afdd368077c006dbd876ddd80424c8bcd/src/core/ModuleManager.sol#L61-L65

Which calls into `SentinelList`:

https://github.com/zeroknots/sentinellist/blob/1f9ec0250f1b3f14ba5d200629e3d9f3264fde61/src/SentinelList.sol#L17-L20


