### PR TITLE
chore: ignore node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ docs/
 
 # Dotenv file
 .env
+
+# External libraries
+node_modules


### PR DESCRIPTION
Add external libraries (`node_modules`) to `.gitignore`.