### PR TITLE
refactor: remove unused return variable in `ModeLib.encode`

### DIFF
--- a/src/lib/ModeLib.sol
+++ b/src/lib/ModeLib.sol
@@ -111,7 +111,7 @@ library ModeLib {
     )
         internal
         pure
-        returns (ModeCode _mode)
+        returns (ModeCode)
     {
         return ModeCode.wrap(
             bytes32(


### PR DESCRIPTION
In the `ModeLib.sol` library, the return variable name `_mode` in a function was removed because the variable was never assigned to.  

This change simplifies the function signature without affecting functionality.